### PR TITLE
Florence finance arb migration

### DIFF
--- a/projects/florence-finance/index.js
+++ b/projects/florence-finance/index.js
@@ -1,21 +1,48 @@
 
-const FACTORY_CONTRACT_ETH = "0xD6348E8EacE62Eb3Eb77fBbA8D8c363e375fC455";
-const EURS_CONTRACT_ETH= "0xdb25f211ab05b1c97d595516f45794528a807ad8";
+const CONTRACT_ETH_VAULTS = "0xD6348E8EacE62Eb3Eb77fBbA8D8c363e375fC455";
+const CONTRACT_ETH_BRIDGE= "0xcee284f754e854890e311e3280b767f80797180d";
+const CONTRACT_ETH_EURS = "0xdb25f211ab05b1c97d595516f45794528a807ad8";
+const CONTRACT_ETH_FLR= "0x5e5d9aeec4a6b775a175b883dca61e4297c14ecb";
+const CONTRACT_ARB_VAULTS = "0x19A2106475b29F0ff5053AE026190ce7A9227cE3";
+const CONTRACT_ARB_EURS = "0xd22a58f79e9481d1a88e00c343885a588b34b68b";
 
-async function borrowed(_, _1, _2, { api }) {
+async function borrowedETH(_, _1, _2, { api }) {
   // Get all vaults
   const vaultIds = await api.call({ 
     abi: "function getLoanVaultIds() external view returns (string[])",
-    target: FACTORY_CONTRACT_ETH
+    target: CONTRACT_ETH_VAULTS
   })
-  const vaultContracts = await api.multiCall({  abi: "function getLoanVault (string loanVaultId) external view returns (address)", target: FACTORY_CONTRACT_ETH, calls: vaultIds })
+  const vaultContracts = await api.multiCall({  abi: "function getLoanVault (string loanVaultId) external view returns (address)", target: CONTRACT_ETH_VAULTS, calls: vaultIds })
+  const loans = await api.multiCall({  abi: "function loansOutstanding() external view returns (uint256)", calls: vaultContracts})
+  
+  let sumLoans = 0;
+  loans.forEach((val, i) => sumLoans += Number(val))
+
+  // Subtract Bridged FLR (EURS) to Arbitrum from Ethereum (migration)
+  const migratedAmount = await api.call({ 
+    abi: "function balanceOf(address account) view returns (uint256)",
+    target: CONTRACT_ETH_FLR,
+    params: [CONTRACT_ETH_BRIDGE]
+  })
+
+  // Subtract migratedAmount from sumLoans and express it in terms of EURS (1 Vault Token = 1 EURS)
+  api.add(CONTRACT_ETH_EURS, (sumLoans - migratedAmount) / 1e16)
+}
+
+async function borrowedARB(_, _1, _2, { api }) {
+  // Get all vaults
+  const vaultIds = await api.call({ 
+    abi: "function getLoanVaultIds() external view returns (string[])",
+    target: CONTRACT_ARB_VAULTS
+  })
+  const vaultContracts = await api.multiCall({  abi: "function getLoanVault (string loanVaultId) external view returns (address)", target: CONTRACT_ARB_VAULTS, calls: vaultIds })
   const loans = await api.multiCall({  abi: "function loansOutstanding() external view returns (uint256)", calls: vaultContracts})
   // Take the sum of all vault tokens in terms of EURS (1 Loan Vault Token = 1 EURS Statis) on the platform | 18-2 = 16 atomic units (LV-EURS
-  loans.forEach((val, i) => api.add(EURS_CONTRACT_ETH, val / 1e16))
+  loans.forEach((val, i) => api.add(CONTRACT_ARB_EURS, val / 1e16))
 }
 
 module.exports = {
-  start: 16077400,
-  methodology: "Data is retrieved on-chain by taking the total sum of all loans outstanding (dominated in EURS Statis) from all platform vaults.",
-  ethereum: { borrowed, tvl: () => ({}) }
+  methodology: "Data is retrieved on-chain by taking the total sum of all loans outstanding (dominated in EURS Statis) from all platform vaults. Florence Finance is currently migrating from Ethereum to Arbitrum.",
+  ethereum: { start: 16077400, borrowed: borrowedETH, tvl: () => ({}) },
+  arbitrum: { start: 126183410, borrowed: borrowedARB, tvl: () => ({}) },
 }

--- a/projects/florence-finance/index.js
+++ b/projects/florence-finance/index.js
@@ -37,12 +37,13 @@ async function borrowedARB(_, _1, _2, { api }) {
   })
   const vaultContracts = await api.multiCall({  abi: "function getLoanVault (string loanVaultId) external view returns (address)", target: CONTRACT_ARB_VAULTS, calls: vaultIds })
   const loans = await api.multiCall({  abi: "function loansOutstanding() external view returns (uint256)", calls: vaultContracts})
-  // Take the sum of all vault tokens in terms of EURS (1 Loan Vault Token = 1 EURS Statis) on the platform | 18-2 = 16 atomic units (LV-EURS
+
+  // Take the sum of all vault tokens in terms of EURS (1 Loan Vault Token = 1 EURS Statis) on the platform | 18-2 = 16 atomic units (LV-EURS)
   loans.forEach((val, i) => api.add(CONTRACT_ARB_EURS, val / 1e16))
 }
 
 module.exports = {
   methodology: "Data is retrieved on-chain by taking the total sum of all loans outstanding (dominated in EURS Statis) from all platform vaults. Florence Finance is currently migrating from Ethereum to Arbitrum.",
   ethereum: { start: 16077400, borrowed: borrowedETH, tvl: () => ({}) },
-  arbitrum: { start: 126183410, borrowed: borrowedARB, tvl: () => ({}) },
+  //arbitrum: { start: 126183410, borrowed: borrowedARB, tvl: () => ({}) },
 }


### PR DESCRIPTION
![image](https://github.com/florence-finance/DefiLlama-Adapters/assets/56940439/eeebcce1-e6b5-4ff4-9a43-9f4c241d1bcb)

Took the liberty to also add the Arbitrum Borrowed function but disabled it for now as the vaults currently mirror the mainnet.

You can test the script locally with:

$ npm install
$ export LLAMA_DEBUG_MODE="true" 
$ node test.js projects/florence-finance/index.js 